### PR TITLE
Add ExperimentalSnapPickerApi marker

### DIFF
--- a/snappicker-compose/src/main/kotlin/io/woong/snappicker/compose/ExperimentalSnapPickerApi.kt
+++ b/snappicker-compose/src/main/kotlin/io/woong/snappicker/compose/ExperimentalSnapPickerApi.kt
@@ -1,0 +1,12 @@
+package io.woong.snappicker.compose
+
+/**
+ * Marker for experimental feature.
+ * Experimental features could be changed or removed.
+ */
+@RequiresOptIn(
+    message = "This is experimental API. It could be removed or changed in the future.",
+    level = RequiresOptIn.Level.ERROR
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalSnapPickerApi


### PR DESCRIPTION
This marker annotaion is added for marking features as experimental.
Experimental features can be changed in future.
The marker can warn to libray users this risk.