### PR TITLE
Remove initialValue and add initialIndex to ValuePickerState and make ValuePicker can select initial index

### DIFF
--- a/samples/src/main/java/com/example/wheelpicker/basicpicker/BasicNumberPickerComposeSample.kt
+++ b/samples/src/main/java/com/example/wheelpicker/basicpicker/BasicNumberPickerComposeSample.kt
@@ -53,7 +53,7 @@ private fun SampleContent() {
             .background(Color(0xfff9f9f9))
     ) {
         val values = remember { (0..23).toList() }
-        val state = rememberValuePickerState(initialValue = values[3])
+        val state = rememberValuePickerState<Int>(initialIndex = 3)
 
         Column(
             modifier = Modifier
@@ -73,7 +73,7 @@ private fun SampleContent() {
                     append("Selected Value: ")
                 }
                 withStyle(SpanStyle(fontSize = 18.sp, color = Color.Gray)) {
-                    append("${state.currentValue}")
+                    append("${values[state.currentIndex]}")
                 }
             })
             BasicText(text = buildAnnotatedString {

--- a/wheelpicker-compose/src/main/kotlin/io/woong/wheelpicker/compose/ValuePicker.kt
+++ b/wheelpicker-compose/src/main/kotlin/io/woong/wheelpicker/compose/ValuePicker.kt
@@ -90,6 +90,7 @@ public fun <T : Any> ValuePicker(
                     androidValuePickerView.itemHeight = itemHeightPx
                     androidValuePickerView.isCyclic = isCyclic
                     androidValuePickerView.setOnValueSelectedListener(valueSelectedListener)
+                    androidValuePickerView.scrollToIndex(state.initialIndex)
                     androidValuePickerView.addOnScrollListener(scrollStateListener)
                     androidValuePickerView
                 },

--- a/wheelpicker-compose/src/main/kotlin/io/woong/wheelpicker/compose/ValuePicker.kt
+++ b/wheelpicker-compose/src/main/kotlin/io/woong/wheelpicker/compose/ValuePicker.kt
@@ -48,7 +48,7 @@ import io.woong.wheelpicker.ValuePickerView
 public fun <T : Any> ValuePicker(
     values: List<T>,
     modifier: Modifier = Modifier,
-    state: ValuePickerState<T> = rememberValuePickerState(initialValue = values[0]),
+    state: ValuePickerState<T> = rememberValuePickerState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     itemHeight: Dp = 48.dp,
     isCyclic: Boolean = false,
@@ -61,7 +61,7 @@ public fun <T : Any> ValuePicker(
 
         val valueSelectedListener = remember {
             ValuePickerView.OnValueSelectedListener { _, index ->
-                state.currentValue = values[index]
+                state.currentIndex = index
             }
         }
 

--- a/wheelpicker-compose/src/main/kotlin/io/woong/wheelpicker/compose/ValuePickerState.kt
+++ b/wheelpicker-compose/src/main/kotlin/io/woong/wheelpicker/compose/ValuePickerState.kt
@@ -28,18 +28,18 @@ import androidx.compose.runtime.setValue
  * A state object to handle [ValuePicker]. In most cases, it can be used with
  * [rememberValuePickerState].
  *
- * @param initialValue The initial value of the picker.
+ * @param initialIndex The initial selected value of the picker.
  * @param onValueSelect Optional callback that invoked when selected value changed.
  */
 @Stable
 public class ValuePickerState<T>(
-    initialValue: T,
-    internal val onValueSelect: (value: T) -> Unit = {},
+    internal val initialIndex: Int,
+    internal val onValueSelect: (value: T) -> Unit,
 ) {
     /**
-     * The current value of this picker.
+     * The current selected index of this picker.
      */
-    public var currentValue: T by mutableStateOf(initialValue)
+    public var currentIndex: Int by mutableStateOf(initialIndex)
         internal set
 
     /**
@@ -52,12 +52,38 @@ public class ValuePickerState<T>(
         /**
          * The default [Saver] implementation for [ValuePickerState].
          */
-        public fun <T : Any> Saver(onValueSelect: (value: T) -> Unit): Saver<ValuePickerState<T>, T> {
+        public fun <T : Any> Saver(onValueSelect: (value: T) -> Unit): Saver<ValuePickerState<T>, Int> {
             return Saver(
-                save = { it.currentValue },
-                restore = { ValuePickerState(it, onValueSelect) },
+                save = {
+                    it.currentIndex
+                },
+                restore = {
+                    ValuePickerState(it, onValueSelect)
+                },
             )
         }
+    }
+}
+
+/**
+ * Creates and remembers a [ValuePickerState] to handle [ValuePicker].
+ *
+ * @param initialIndex The initial selected index of the picker.
+ * @param onValueSelect Optional callback that invoked when selected value changed.
+ */
+@Stable
+@Composable
+public fun <T : Any> rememberValuePickerState(
+    initialIndex: Int = 0,
+    onValueSelect: (value: T) -> Unit = {},
+): ValuePickerState<T> {
+    return rememberSaveable(
+        saver = ValuePickerState.Saver(onValueSelect = onValueSelect)
+    ) {
+        ValuePickerState(
+            initialIndex = initialIndex,
+            onValueSelect = onValueSelect,
+        )
     }
 }
 
@@ -67,6 +93,7 @@ public class ValuePickerState<T>(
  * @param initialValue The initial value of the picker.
  * @param onValueSelect Optional callback that invoked when selected value changed.
  */
+@Deprecated("Use rememberValuePickerState with initialIndex instead.")
 @Stable
 @Composable
 public fun <T : Any> rememberValuePickerState(
@@ -77,7 +104,7 @@ public fun <T : Any> rememberValuePickerState(
         saver = ValuePickerState.Saver(onValueSelect = onValueSelect)
     ) {
         ValuePickerState(
-            initialValue = initialValue,
+            initialIndex = 0,
             onValueSelect = onValueSelect,
         )
     }

--- a/wheelpicker/src/main/java/io/woong/wheelpicker/ValuePickerView.kt
+++ b/wheelpicker/src/main/java/io/woong/wheelpicker/ValuePickerView.kt
@@ -121,16 +121,7 @@ public class ValuePickerView : FrameLayout {
         alphaEffector.attachToPickerView(this)
 
         addView(recyclerView)
-        postMoveToInitialPosition(initialIndex)
-    }
-
-    private fun postMoveToInitialPosition(initialIndex: Int) = post {
-        if (isCyclic) {
-            val pos = cyclicPickerRepositionHelper.findApproximatelyCenterPosition(initialIndex)
-            scrollToPosition(pos)
-        } else {
-            scrollToPosition(initialIndex)
-        }
+        scrollToIndex(initialIndex)
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
@@ -163,11 +154,30 @@ public class ValuePickerView : FrameLayout {
     /**
      * Move this picker's scroll position to the given position without animation.
      *
-     * @param position The destination index.
+     * Note: the [position] is related to internal scroll position, not a selected index. To move
+     * to a specified selected index, use [scrollToIndex] instead.
+     *
+     * @param position A destination scroll position.
      */
     public fun scrollToPosition(position: Int) {
         val layoutManager = recyclerView.layoutManager as LinearLayoutManager
         layoutManager.scrollToPosition(position)
+    }
+
+    /**
+     * Move selected index to specified index without animation.
+     *
+     * @param index A destination selected index.
+     */
+    public fun scrollToIndex(index: Int) {
+        post {
+            if (isCyclic) {
+                val pos = cyclicPickerRepositionHelper.findApproximatelyCenterPosition(index)
+                scrollToPosition(pos)
+            } else {
+                scrollToPosition(index)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR contains breaking changes and fixing #13.

`ValuePickerState`'s `currentValue` property is now removed and `currentIndex` is added. For fixing #13, this change is inevitable. Because the state can't know value list.

Now `ValuePickerState` doesn't have `currentValue`, `rememberValuePickerState` is also changed. Now `rememberValuePickerState` with `initialValue` is deprecated and a same named remember function with `initialIndex` is added.